### PR TITLE
Fix bug in 2.11 macros.

### DIFF
--- a/src/main/scala-2.11/org/log4s/LoggerMacros.scala
+++ b/src/main/scala-2.11/org/log4s/LoggerMacros.scala
@@ -80,7 +80,7 @@ private[log4s] object LoggerMacros {
       case None    => List(msg.tree)
       case Some(e) => List(msg.tree, e.tree)
     }
-    val logExpr = q"$logger.${TermName(logLevel.methodName)}(...$logValues)"
+    val logExpr = q"$logger.${TermName(logLevel.methodName)}(..$logValues)"
     val checkExpr = q"$logger.${TermName(s"is${logLevel.name}Enabled")}()"
 
     def errorIsSimple = {

--- a/src/test/scala/org/log4s/LoggerSpec.scala
+++ b/src/test/scala/org/log4s/LoggerSpec.scala
@@ -11,6 +11,26 @@ class LoggerSpec extends FlatSpec with Matchers {
 
   behavior of "getLogger"
 
+  // these are strictly compile tests for the macro generators.
+  it should "properly compile trace logging events" in {
+    logger.trace("foo")
+    logger.trace(new Exception())("foo")
+
+    logger.debug("Foo")
+    logger.debug(new Exception())("foo")
+
+    logger.info("Foo")
+    logger.info(new Exception())("foo")
+
+    logger.warn("Foo")
+    logger.warn(new Exception())("foo")
+
+    logger.error("Foo")
+    logger.error(new Exception())("foo")
+
+    true shouldEqual true
+  }
+
   it should "properly name class loggers" in {
     logger.name shouldEqual "org.log4s.LoggerSpec"
   }
@@ -97,6 +117,10 @@ class LoggerSpec extends FlatSpec with Matchers {
 
   it should "support explicit logger names" in {
     getLogger("a.b.c").name shouldEqual "a.b.c"
+  }
+
+  it should "compile error log messages" in {
+    true shouldEqual true
   }
 }
 


### PR DESCRIPTION
It was a single period that would turn turn the params list into a curried set of params. It works when no exception is present because there is then only one set of params.

Eg: 

``` scala
logger.trace(new Exception())("foo") ==  logger.logger.trace("foo")(new scala.`package`.Exception())
```

instead of the desired

``` scala
 logger.logger.trace("foo", new scala.`package`.Exception())
```

See [Quasiquotes splicing docs](http://docs.scala-lang.org/overviews/quasiquotes/intro.html#splicing) for more details.

Added some 'it must compile' tests.
