### PR TITLE
be Scala community build friendly

### DIFF
--- a/project/Helpers.scala
+++ b/project/Helpers.scala
@@ -26,10 +26,10 @@ object Helpers {
   }
   object SVer {
     def apply(scalaVersion: String): SVer = {
-      scalaVersion match {
-        case "2.10"       => SVer2_10
-        case "2.11"       => SVer2_11
-        case "2.12"       => SVer2_12
+      sbt.CrossVersion.partialVersion(scalaVersion) match {
+        case Some((2, 10))           => SVer2_10
+        case Some((2, 11))           => SVer2_11
+        case Some((2, n)) if n >= 12 => SVer2_12
       }
     }
   }


### PR DESCRIPTION
with these two changes to Scala version number handling:
* use CrossVersion.partialVersion so it doesn't blow up on
  Scala versions like "2.12.2-c94a9b2-nightly"
* treat 2.13 the same as 2.12 for now (yes, there is already a 2.13
  community build)