### PR TITLE
makeSite on all pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ scala:
   - 2.13.0-RC1
   - 2.13.0-RC2
 script:
-  - 'sbt -Dsbt.log.noformat=true ++$TRAVIS_SCALA_VERSION test'
-  - 'if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_BRANCH}" = "master" ]; then sbt ++$TRAVIS_SCALA_VERSION make-site publish; fi'
+  - 'sbt -Dsbt.log.noformat=true ++$TRAVIS_SCALA_VERSION test makeSite'
+  - 'if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_BRANCH}" = "master" ]; then sbt ++$TRAVIS_SCALA_VERSION publish; fi'
 jdk:
   - openjdk8
 env:


### PR DESCRIPTION
Moves the `makeSite` task to all builds.  If the docs break, this should catch it before it gets merged.

Also modernizes the kebab case `make-site`, which is no longer supported.