### PR TITLE
Support Scala 2.13, drop 2.13.0-RC*

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,7 @@ scala:
   - 2.10.7
   - 2.11.12
   - 2.12.8
-  - 2.13.0-RC1
-  - 2.13.0-RC2
-  - 2.13.0-RC3
+  - 2.13.0
 script:
   - 'sbt -Dsbt.log.noformat=true ++$TRAVIS_SCALA_VERSION test makeSite'
   - 'if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_BRANCH}" = "master" ]; then sbt ++$TRAVIS_SCALA_VERSION publish; fi'

--- a/build.sbt
+++ b/build.sbt
@@ -83,7 +83,7 @@ lazy val core = (crossProject(JSPlatform, JVMPlatform) in file ("core"))
       slf4j,
       logback          %   "test",
       "org.scalacheck" %%% "scalacheck" % scalacheckVersion % "test",
-      "org.scalatest"  %%% "scalatest"  % scalatestVersion.value % "test",
+      "org.scalatest"  %%% "scalatest"  % scalatestVersion % "test",
       reflect.value    %   "provided"
     ),
 
@@ -158,12 +158,8 @@ lazy val testing = (crossProject(JSPlatform, JVMPlatform) in file ("testing"))
   .jvmSettings(
     prevVersions := {
       scalaBinaryVersion.value match {
-        case "2.10" | "2.11" | "2.12" | "2.13.0-M2" =>
+        case "2.10" | "2.11" | "2.12" =>
           Set("1.5.0", "1.6.0", "1.6.1", "1.7.0", "1.8.0", "1.8.1")
-        case "2.13.0-RC1" | "2.13.0-RC2" =>
-          Set("1.8.0", "1.8.1")
-        case "2.13.0-RC3" =>
-          Set("1.8.1")
         case other =>
           Set.empty
       }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,15 +5,7 @@ object Dependencies {
   final val slf4jVersion      = "1.7.25"
   final val logbackVersion    = "1.2.3"
   final val scalacheckVersion = "1.14.0"
-
-  val scalatestVersion = Def.map(scalaBinaryVersion) {
-    case "2.13.0-M3"  => "3.0.5-M1"
-    case "2.13.0-M5"  => "3.0.6-SNAP6"
-    case "2.13.0-RC1" => "3.0.8-RC2"
-    case "2.13.0-RC2" => "3.0.8-RC4"
-    case "2.13.0-RC3" => "3.0.8-RC5"
-    case other        => "3.0.5"
-  }
+  final val scalatestVersion  = "3.0.8"  
 
   val slf4j     = "org.slf4j"      % "slf4j-api"       % slf4jVersion
   val logback   = "ch.qos.logback" % "logback-classic" % logbackVersion

--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -16,7 +16,7 @@ trait ProjectSettings
   override final val githubProject            = "log4s"
 
   override final val buildScalaVersion        = "2.12.8"
-  override final val extraScalaVersions       = Seq("2.10.7", "2.11.12", "2.13.0-RC1", "2.13.0-RC2", "2.13.0-RC3")
+  override final val extraScalaVersions       = Seq("2.10.7", "2.11.12", "2.13.0")
   override final val minimumJavaVersion       = "1.7"
   override final val defaultOptimize          = true
   override final val defaultOptimizeGlobal    = true


### PR DESCRIPTION
Drops the RC support, as proposed in #37.  I can make it work if there's pushback, but this is simpler.

Will require a bit of follow-up on `prevVersions` after there is a Scala 2.13 release to check.