### PR TITLE
Update prevVersions after 1.8.2 release

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -122,12 +122,13 @@ lazy val core = (crossProject(JSPlatform, JVMPlatform) in file ("core"))
             "1.5.0",
             "1.6.0", "1.6.1",
             "1.7.0",
-            "1.8.0", "1.8.1")
+            "1.8.0")
+      def `2.13Versions` =
+        Set("1.8.2")
       scalaBinaryVersion.value match {
-        case "2.10" | "2.11"             => `2.11Versions` ++ `2.12Versions`
-        case "2.12"                      => `2.12Versions`
-        case "2.13.0-RC1" | "2.13.0-RC2" => Set("1.8.0", "1.8.1")
-        case "2.13.0-RC3"                => Set("1.8.1")
+        case "2.10" | "2.11"             => `2.11Versions` ++ `2.12Versions` ++ `2.13Versions`
+        case "2.12"                      => `2.12Versions` ++ `2.13Versions`
+        case "2.13"                      => `2.13Versions`
         case other                       =>
           sLog.value.info(s"No known MIMA artifacts for: $other")
           Set.empty
@@ -159,7 +160,9 @@ lazy val testing = (crossProject(JSPlatform, JVMPlatform) in file ("testing"))
     prevVersions := {
       scalaBinaryVersion.value match {
         case "2.10" | "2.11" | "2.12" =>
-          Set("1.5.0", "1.6.0", "1.6.1", "1.7.0", "1.8.0", "1.8.1")
+          Set("1.5.0", "1.6.0", "1.6.1", "1.7.0", "1.8.0", "1.8.2")
+        case "2.13" =>
+          Set("1.8.2")
         case other =>
           Set.empty
       }


### PR DESCRIPTION
An alternative that could be easier to maintain would be to introspect the versions from the tags, but we'd need to redo the logic to filter out the experimental modules and unavailable crossbuilds.  It'd be more work now, but automated with releases moving forward, until more exceptions arise.

This is the unambitious approach.