### PR TITLE
Use fully-qualified classOf from scala.Predef

### DIFF
--- a/core/shared/src/main/scala-2.11/org/log4s/LoggerMacros.scala
+++ b/core/shared/src/main/scala-2.11/org/log4s/LoggerMacros.scala
@@ -62,7 +62,7 @@ private[log4s] object LoggerMacros {
       val typeParams = typeSymbol.typeParams
 
       if (typeParams.isEmpty) {
-        loggerByParam(q"classOf[$typeSymbol]")
+        loggerByParam(q"_root_.scala.Predef.classOf[$typeSymbol]")
       } else {
         if (typeParams.exists(_.asType.typeParams.nonEmpty)) {
           /* We have at least one higher-kinded type: fall back to by-name logger construction, as
@@ -71,7 +71,7 @@ private[log4s] object LoggerMacros {
         } else {
           val typeArgs = List.fill(typeParams.length)(WildcardType)
           val typeConstructor = tq"$typeSymbol[..${typeArgs}]"
-          loggerByParam(q"classOf[$typeConstructor]")
+          loggerByParam(q"_root_.scala.Predef.classOf[$typeConstructor]")
         }
       }
     }

--- a/core/shared/src/test/scala/org/log4s/GetLoggerSpec.scala
+++ b/core/shared/src/test/scala/org/log4s/GetLoggerSpec.scala
@@ -115,6 +115,11 @@ class GetLoggerSpec extends FlatSpec with Matchers with GivenWhenThen with Logge
     val hkt = new GetLoggerSpecKinds.NestedKind1[Seq]
     hkt.logger.name shouldEqual "org.log4s.GetLoggerSpecKinds.NestedKind1"
   }
+
+  it should "use classOf from scala.Predef" in {
+    val classOf = 1 // shadow the symbol to make compilation fail if it’s attempted to be used
+    getLogger.name shouldEqual "org.log4s.GetLoggerSpec"
+  }
 }
 
 private class GetLoggerSpecParam[A] {


### PR DESCRIPTION
The macro implementation of `getLogger` uses an unqualified `classOf` symbol, which means calls to `getLogger` fail to compile if there either is no `classOf` in scope (e.g. `-Yno-predef`) or if it has been shadowed.

This can be fixed by using a fully qualified reference to `classOf` from `_root_.scala.Predef`.