### PR TITLE
Scala.js 1.0 support. Upgrade to Scala 2.12.11, 2.13.2. Drop Scala 2.10.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,20 +4,15 @@ branches:
     - /^v\d/
 language: scala
 scala:
-  - 2.10.7
   - 2.11.12
-  - 2.12.8
-  - 2.13.0
+  - 2.12.11
+  - 2.13.2
 script:
   - 'sbt -Dsbt.log.noformat=true ++$TRAVIS_SCALA_VERSION test makeSite'
   - 'if [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_BRANCH}" = "master" ]; then sbt ++$TRAVIS_SCALA_VERSION publish; fi'
 jdk:
   - openjdk8
   - openjdk11
-matrix:
-  exclude:
-    - jdk: openjdk11
-      scala: 2.10.7
 env:
   global:
   - secure: LZqtbvSqVPpycaMLC9FnCaEs70WLt9tr+477t6jdCwyUgkaRfcBvLVeh/EsH4RJW+GtvNqmpZ43dpUGrnxZktFvZz+1LdPNtVggLza+ysMd/KlVlSXT1Re1NvArc4nE9Po+hQws26ehvlk2+BKh0e5SfXRU/3+NDs1H0bgtkQVU=

--- a/build.sbt
+++ b/build.sbt
@@ -25,18 +25,10 @@ releaseProcess := Seq[ReleaseStep](
 )
 val prevVersions = settingKey[Set[String]]("The previous versions for the current project")
 val prevArtifacts = Def.derive {
-  mimaPreviousArtifacts := {
-    /* TODO: I imagine there's a better way to do this */
-    val artName = {
-      val suffix = if (isScalaJSProject.value) "_sjs0.6" else ""
-      artifact.value.name + suffix
-    }
-    prevVersions.value.map(organization.value %% artName % _)
-  }
+  mimaPreviousArtifacts := prevVersions.value.map(organization.value %%% artifact.value.name % _)
 }
 
 def jsOpts = new Def.SettingList(Seq(
-  scalacOptions += "-P:scalajs:sjsDefinedByDefault",
   scalaJSLinkerConfig ~= { _.withModuleKind(ModuleKind.CommonJSModule) }
 ))
 
@@ -81,10 +73,11 @@ lazy val core = (crossProject(JSPlatform, JVMPlatform) in file ("core"))
 
     libraryDependencies ++= Seq (
       slf4j,
-      logback          %   "test",
-      "org.scalacheck" %%% "scalacheck" % scalacheckVersion % "test",
-      "org.scalatest"  %%% "scalatest"  % scalatestVersion % "test",
-      reflect.value    %   "provided"
+      logback             %   "test",
+      "org.scalacheck"    %%% "scalacheck"      % scalacheckVersion              % "test",
+      "org.scalatest"     %%% "scalatest"       % scalatestVersion               % "test",
+      "org.scalatestplus" %%% "scalacheck-1-14" % scalatestPlusScalacheckVersion % "test",
+      reflect.value       %   "provided"
     ),
 
     unmanagedSourceDirectories in Compile ++= {
@@ -107,7 +100,7 @@ lazy val core = (crossProject(JSPlatform, JVMPlatform) in file ("core"))
 
   )
   .jvmSettings(
-    libraryDependencies += "org.scala-js" %% "scalajs-stubs" % scalaJSVersion % "provided",
+    libraryDependencies += "org.scala-js" %% "scalajs-stubs" % scalajsStubsVersion % "provided",
     prevVersions := {
       /* I'm using the first & last version of each minor release rather than
        * including every single patch-level update. */

--- a/core/js/src/main/scala/org/log4s/log4sjs/Log4s.scala
+++ b/core/js/src/main/scala/org/log4s/log4sjs/Log4s.scala
@@ -10,7 +10,7 @@ object Log4s {
   @JSExport("getLogger")
   def getLogger(name: String) = org.slf4j.LoggerFactory.getLogger(name)
   @JSExport("Config")
-  val Config = Log4sConfig
+  val Config = org.log4s.log4sjs.Log4sConfig
   @JSExport("MDC")
   val MDC = log4sjs.Log4sMDC
   @JSExport("LogThreshold")

--- a/core/js/src/main/scala/org/log4s/log4sjs/Log4sLoggerFactory.scala
+++ b/core/js/src/main/scala/org/log4s/log4sjs/Log4sLoggerFactory.scala
@@ -6,7 +6,7 @@ import scala.scalajs.js
 import org.slf4j.{ ILoggerFactory, Logger }
 
 class Log4sLoggerFactory extends ILoggerFactory {
-  @inline private final def config = Log4sConfig
+  @inline private final def config = org.log4s.log4sjs.Log4sConfig
   private[this] final class Log4sLoggerInstance private[Log4sLoggerFactory] (private[this] val name: String) extends Logger {
     private[this] val path = LoggerParser(name)
 

--- a/core/js/src/test/scala/org/log4s/CategoryParserTest.scala
+++ b/core/js/src/test/scala/org/log4s/CategoryParserTest.scala
@@ -5,9 +5,10 @@ import scala.collection.immutable.{ Seq => ISeq }
 import org.scalacheck._
 import org.scalacheck.Arbitrary._
 
-import org.scalatest._
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.Matchers._
+import org.scalatest.Assertion
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers._
 
 private object LoggerParserSpec {
   private[this] final val catParser = LoggerParser
@@ -56,7 +57,7 @@ private object LoggerParserSpec {
 
 import LoggerParserSpec._
 
-class LoggerParserSpec extends FlatSpec with PropertyChecks {
+class LoggerParserSpec extends AnyFlatSpec with ScalaCheckPropertyChecks {
   it should "handle the root logger correctly" in {
     "" should select loggerOf (Nil)
   }

--- a/core/shared/src/test/scala/org/log4s/GetLoggerSpec.scala
+++ b/core/shared/src/test/scala/org/log4s/GetLoggerSpec.scala
@@ -2,13 +2,15 @@ package org.log4s
 
 import language.higherKinds
 
-import org.scalatest._
+import org.scalatest.GivenWhenThen
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /** Test suite for the behavior of `getLogger`.
   *
   * @author Sarah Gerweck <sarah@atscale.com>
   */
-class GetLoggerSpec extends FlatSpec with Matchers with GivenWhenThen with LoggerInit {
+class GetLoggerSpec extends AnyFlatSpec with Matchers with GivenWhenThen with LoggerInit {
   private[this] val logger = getLogger
 
   behavior of "getLogger"

--- a/core/shared/src/test/scala/org/log4s/LoggerSpec.scala
+++ b/core/shared/src/test/scala/org/log4s/LoggerSpec.scala
@@ -1,6 +1,8 @@
 package org.log4s
 
-import org.scalatest._
+import org.scalatest.GivenWhenThen
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 import ch.qos.logback.classic.{ Level => Lvl }
 
@@ -8,7 +10,7 @@ import ch.qos.logback.classic.{ Level => Lvl }
   *
   * @author Sarah Gerweck <sarah@atscale.com>
   */
-class LoggerSpec extends FlatSpec with Matchers with GivenWhenThen with LoggerInit {
+class LoggerSpec extends AnyFlatSpec with Matchers with GivenWhenThen with LoggerInit {
   private[this] val testLogger = getLogger("test")
   private[this] val traceLogger = getLogger("level.tr")
   private[this] val debugLogger = getLogger("level.de")

--- a/core/shared/src/test/scala/org/log4s/MDCSpec.scala
+++ b/core/shared/src/test/scala/org/log4s/MDCSpec.scala
@@ -1,12 +1,14 @@
 package org.log4s
 
-import org.scalatest._
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
 /** Test specs for mapped diagnostic contexts.
   *
   * @author Sarah Gerweck <sarah@atscale.com>
   */
-class MDCSpec extends FlatSpec with Matchers with BeforeAndAfterAll {
+class MDCSpec extends AnyFlatSpec with Matchers with BeforeAndAfterAll {
   behavior of "MDC"
 
   it should "start out empty" in {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,10 +2,12 @@ import sbt._
 import Keys._
 
 object Dependencies {
-  final val slf4jVersion      = "1.7.25"
-  final val logbackVersion    = "1.2.3"
-  final val scalacheckVersion = "1.14.0"
-  final val scalatestVersion  = "3.0.8"
+  final val slf4jVersion                   = "1.7.25"
+  final val logbackVersion                 = "1.2.3"
+  final val scalacheckVersion              = "1.14.3"
+  final val scalatestVersion               = "3.1.1"
+  final val scalatestPlusScalacheckVersion = "3.1.1.1"
+  final val scalajsStubsVersion            = "1.0.0"
 
   val slf4j     = "org.slf4j"      % "slf4j-api"       % slf4jVersion
   val logback   = "ch.qos.logback" % "logback-classic" % logbackVersion

--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -15,8 +15,8 @@ trait ProjectSettings
   override final val githubOrganization       = "Log4s"
   override final val githubProject            = "log4s"
 
-  override final val buildScalaVersion        = "2.12.8"
-  override final val extraScalaVersions       = Seq("2.10.7", "2.11.12", "2.13.0")
+  override final val buildScalaVersion        = "2.12.11"
+  override final val extraScalaVersions       = Seq("2.11.12", "2.13.2")
   override final val minimumJavaVersion       = "1.7"
   override final val defaultOptimize          = true
   override final val defaultOptimizeGlobal    = true

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.10

--- a/project/plugin-scalajs.sbt
+++ b/project/plugin-scalajs.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "0.6.28")
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.0.1")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")


### PR DESCRIPTION
Upgrade to Scala.js 1.0.

This requires dropping Scala 2.10. If support for 2.10 is still needed, we can exclude it from the Scala.js builds, but in order to achieve this then `extraScalaVersions` needs to be turned into an sbt setting in the build configuration.

Also, Scala.js 0.6.x support is dropped. Cross-compiling between 0.6 and 1.0 implies adding complexity to the publish script which doesn't seem desirable.

Upgrades to scalatest & scalacheck were needed to provide Scala.js 1.0 support.

Scala versions were upgraded to 2.12.11. 2.13.2.

(Supersedes #45)