### PR TITLE
Release notes for 1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,3 +104,11 @@ changes to how it's coded or built, see the Git history.
 ### 1.8.2
 
 * Add support for Scala 2.13.0
+
+### 1.9.0
+
+* Set internal flag to prevent second initialization
+* Use fully-qualified `classOf` from `scala.Predef`
+* Add support for Scala.js 1.0
+* Drops support for Scala 2.10
+* Drops support for Scala.js 0.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,3 +112,4 @@ changes to how it's coded or built, see the Git history.
 * Add support for Scala.js 1.0
 * Drops support for Scala 2.10
 * Drops support for Scala.js 0.6
+* Built against Scala 2.13.3 and 2.12.12


### PR DESCRIPTION
Strictly speaking for semver, this could be a patch release, but I wanted to get people's attention since Scala 2.10 and Scala.js 0.6 are dropped.  And since it's non-breaking for what does publish, I didn't want to go as far bumping the major version.  So I compromised: minor bump.