### PR TITLE
Scala 2.12.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ branches:
 language: scala
 scala:
   - 2.11.12
-  - 2.12.11
+  - 2.12.12
   - 2.13.3
 script:
   - 'sbt -Dsbt.log.noformat=true ++$TRAVIS_SCALA_VERSION test makeSite'

--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -15,7 +15,7 @@ trait ProjectSettings
   override final val githubOrganization       = "Log4s"
   override final val githubProject            = "log4s"
 
-  override final val buildScalaVersion        = "2.12.11"
+  override final val buildScalaVersion        = "2.12.12"
   override final val extraScalaVersions       = Seq("2.11.12", "2.13.3")
   override final val minimumJavaVersion       = "1.7"
   override final val defaultOptimize          = true


### PR DESCRIPTION
Should not matter at all for clients, but always nice to test against the latest.

Noticed by @satorg.