### PR TITLE
Reinstate proper Test and Provided scopes

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -102,7 +102,7 @@ lazy val core = (crossProject(JSPlatform, JVMPlatform) in file ("core"))
     ),
     libraryDependencies ++= {
       if (isDotty.value) Seq.empty
-      else Seq(reflect.value)
+      else Seq(reflect.value % Provided)
     },
 
     unmanagedSourceDirectories in Compile ++= {
@@ -127,8 +127,8 @@ lazy val core = (crossProject(JSPlatform, JVMPlatform) in file ("core"))
   .jvmSettings(
     libraryDependencies += ("org.scala-js" %% "scalajs-stubs" % scalajsStubsVersion % "provided").withDottyCompat(scalaVersion.value),
     libraryDependencies ++= Seq(
-      "org.scalatest"     %%% "scalatest"       % scalatestVersion,
-      "org.scalatestplus" %%% "scalacheck-1-15" % scalatestPlusScalacheckVersion
+      "org.scalatest"     %%% "scalatest"       % scalatestVersion               % Test,
+      "org.scalatestplus" %%% "scalacheck-1-15" % scalatestPlusScalacheckVersion % Test
     ),
     prevVersions := {
       /* I'm using the first & last version of each minor release rather than
@@ -166,8 +166,8 @@ lazy val core = (crossProject(JSPlatform, JVMPlatform) in file ("core"))
     prevVersions := jsPrevVersions,
     libraryDependencies ++= {
       if (!isDotty.value) Seq(
-        "org.scalatest"     %%% "scalatest"       % scalatestVersion,
-        "org.scalatestplus" %%% "scalacheck-1-15" % scalatestPlusScalacheckVersion
+        "org.scalatest"     %%% "scalatest"       % scalatestVersion               % Test,
+        "org.scalatestplus" %%% "scalacheck-1-15" % scalatestPlusScalacheckVersion % Test,
       )
       else Seq.empty
     }


### PR DESCRIPTION
I accidentally omitted these in #51, which caused our 1.10.0-M1 artifacts to have test and reflection dependencies.  Eek!