### PR TITLE
determine dependency versions in a dbuild-friendly way

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,18 +12,14 @@ object Dependencies {
   final val scalatestVersion               =
     Def.map(scalaBinaryVersion) {
       case "2.11"      => "3.2.3"
-      case "2.12"      => "3.2.4"
-      case "2.13"      => "3.2.4"
       case "3.0.0-M3"  => "3.2.3"
-      case "3.0.0-RC1" => "3.2.4"
+      case _           => "3.2.4"
     }
   final val scalatestPlusScalacheckVersion =
     Def.map(scalaBinaryVersion) {
       case "2.11"      => "3.2.3.0"
-      case "2.12"      => "3.2.4.0"
-      case "2.13"      => "3.2.4.0"
       case "3.0.0-M3"  => "3.2.3.0"
-      case "3.0.0-RC1" => "3.2.4.0"
+      case _           => "3.2.4.0"
     }
   final val scalajsStubsVersion            = "1.0.0"
 


### PR DESCRIPTION
this is needed for the Scala community build, where dbuild manipulates `scalaBinaryVersion` too, not only `scalaVersion`