### PR TITLE
Release notes for 1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,3 +152,9 @@ changes to how it's coded or built, see the Git history.
 
 * Add support for Scala 3.0.0-RC3
 * Drop support for Scala 3.0.0-RC1
+
+### 1.10.0
+
+* Add support for Scala 3.0.0
+* Drop support for Scala 3.0.0-RC2 and 3.0.0-RC3
+* Add support for Scala.js on Scala 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -157,7 +157,7 @@ changes to how it's coded or built, see the Git history.
 
 * Add support for Scala 3.0.0
 * Drop support for Scala 3.0.0-RC2 and 3.0.0-RC3
-* Add support for Scala.js on Scala 3
+* Add **experimental** support for Scala.js on Scala 3.
 
 ### 1.10.0
 


### PR DESCRIPTION
Mostly to ping @sarahgerweck since this will be a production release instead of the milestone releases I've been doing without her.  The scala.js support for Scala 3 is just a few minutes old, but we've always classified that as experimental anyway.  Releasing this will unblock prod releases of some other projects (e.g., http4s).