### PR TITLE
Fix Scala.js source map URI to point to GitHub; drop Scala 2.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        scala: [2.12.15, 2.11.12, 2.13.8, 3.0.2]
+        scala: [2.12.21, 2.13.18, 3.3.7]
         java: [temurin@8, temurin@11, temurin@17]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Java (temurin@8)
         id: setup-java-temurin-8
         if: matrix.java == 'temurin@8'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 8
@@ -56,7 +56,7 @@ jobs:
       - name: Setup Java (temurin@11)
         id: setup-java-temurin-11
         if: matrix.java == 'temurin@11'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 11
@@ -69,7 +69,7 @@ jobs:
       - name: Setup Java (temurin@17)
         id: setup-java-temurin-17
         if: matrix.java == 'temurin@17'
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 17

--- a/README.md
+++ b/README.md
@@ -46,17 +46,9 @@ facilitating the testing of logging-related code.
 
 ### Requirements
 
-Scala 2.11, 2.12 and 2.13 are fully supported. No special settings or
+Scala 2.12, 2.13 and 3 are fully supported. No special settings or
 compiler options are required: just add the dependency as described
 above.
-
-#### Scala 2.10
-
-Scala 2.10 support is still present, but it is beyond its support window: it
-may be removed in any future minor release if there's a reason. (It will not
-be removed in a patch release.)
-
-The macro paradise compiler extensions are not required for Scala 2.10.
 
 ### Getting a logger
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,7 @@ import Dependencies._
 import ReleaseTransformations._
 
 import sbtcrossproject.CrossPlugin.autoImport.{crossProject, CrossType}
+import org.typelevel.sbt.TypelevelScalaJSGitHubPlugin
 
 /* TODO: Attempts to do this with the existing `TaskKey` have failed, but that
  * would be better than doing it using the string. This approach also won't
@@ -59,7 +60,7 @@ def jsOpts = new Def.SettingList(Seq(
 ))
 
 lazy val root: Project = (project in file ("."))
-  .enablePlugins(BasicSettings)
+  .enablePlugins(BasicSettings, TypelevelScalaJSGitHubPlugin)
   .settings(Publish.settings: _*)
   .settings(Release.settings: _*)
   .aggregate(coreJVM, coreJS, testingJVM, testingJS)

--- a/build.sbt
+++ b/build.sbt
@@ -119,7 +119,7 @@ lazy val core = (crossProject(JSPlatform, JVMPlatform) in file ("core"))
     libraryDependencies ++= Seq (
       slf4j,
       logback             %   "test",
-      "org.scalacheck"    %%% "scalacheck"      % scalacheckVersion.value          % "test",
+      "org.scalacheck"    %%% "scalacheck"      % scalacheckVersion          % "test",
     ),
     libraryDependencies ++= {
       if (isScala3(scalaVersion.value)) Seq.empty
@@ -128,16 +128,7 @@ lazy val core = (crossProject(JSPlatform, JVMPlatform) in file ("core"))
 
     Compile / unmanagedSourceDirectories ++= {
       scalaBinaryVersion.value match {
-        case s if s.startsWith("2.") =>
-          Seq(baseDirectory.value / ".." / "shared" / "src" / "main" / "scala-2")
-        case s if s.startsWith("3") =>
-          Seq.empty
-      }
-    },
-
-    Compile / unmanagedSourceDirectories ++= {
-      scalaBinaryVersion.value match {
-        case "2.11" | "2.12" =>
+        case "2.12" =>
           Seq(baseDirectory.value / ".." / "shared" / "src" / "main" / "scala-oldcoll")
         case _ =>
           Seq(baseDirectory.value / ".." / "shared" / "src" / "main" / "scala-newcoll")
@@ -148,17 +139,12 @@ lazy val core = (crossProject(JSPlatform, JVMPlatform) in file ("core"))
   .jvmSettings(
     libraryDependencies += ("org.scala-js" %% "scalajs-stubs" % scalajsStubsVersion % "provided").cross(CrossVersion.for3Use2_13),
     libraryDependencies ++= Seq(
-      "org.scalatest"     %%% "scalatest"       % scalatestVersion.value               % Test,
-      "org.scalatestplus" %%% "scalacheck-1-15" % scalatestPlusScalacheckVersion.value % Test
+      "org.scalatest"     %%% "scalatest"       % scalatestVersion               % Test,
+      "org.scalatestplus" %%% "scalacheck-1-15" % scalatestPlusScalacheckVersion % Test
     ),
     prevVersions := {
       /* I'm using the first & last version of each minor release rather than
        * including every single patch-level update. */
-      def `2.11Versions` =
-        Set("1.0.3", "1.0.5",
-            "1.1.0", "1.1.5",
-            "1.2.0", "1.2.1",
-            "1.3.0")
       def `2.12Versions` =
         Set("1.3.3", "1.3.6",
             "1.4.0",
@@ -172,7 +158,6 @@ lazy val core = (crossProject(JSPlatform, JVMPlatform) in file ("core"))
       def DottyVersions =
         Set.empty[String]
       scalaBinaryVersion.value match {
-        case "2.11" => `2.11Versions` ++ `2.12Versions` ++ `2.13Versions` ++ DottyVersions
         case "2.12" => `2.12Versions` ++ `2.13Versions` ++ DottyVersions
         case "2.13" => `2.13Versions` ++ DottyVersions
         case "3"    => DottyVersions
@@ -187,8 +172,8 @@ lazy val core = (crossProject(JSPlatform, JVMPlatform) in file ("core"))
     prevVersions := jsPrevVersions,
     libraryDependencies ++= {
       Seq(
-        "org.scalatest"     %%% "scalatest"       % scalatestVersion.value               % Test,
-        "org.scalatestplus" %%% "scalacheck-1-15" % scalatestPlusScalacheckVersion.value % Test,
+        "org.scalatest"     %%% "scalatest"       % scalatestVersion               % Test,
+        "org.scalatestplus" %%% "scalacheck-1-15" % scalatestPlusScalacheckVersion % Test,
       )
     }
   )
@@ -215,7 +200,7 @@ lazy val testing = (crossProject(JSPlatform, JVMPlatform) in file ("testing"))
       val `2.13Versions` = Set("1.8.2")
       val DottyVersions  = Set.empty[String]
       scalaBinaryVersion.value match {
-        case "2.11" | "2.12" => `2.12Versions` ++ `2.13Versions` ++ DottyVersions
+        case "2.12" => `2.12Versions` ++ `2.13Versions` ++ DottyVersions
         case "2.13"          => `2.13Versions` ++ DottyVersions
         case "3"             => DottyVersions
         case other =>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,21 +4,9 @@ import Keys._
 object Dependencies {
   final val slf4jVersion                   = "1.7.36"
   final val logbackVersion                 = "1.2.3"
-  final val scalacheckVersion              =
-    Def.map(scalaBinaryVersion) {
-      case "2.11"      => "1.15.2"
-      case _           => "1.15.3"
-    }
-  final val scalatestVersion               =
-    Def.map(scalaBinaryVersion) {
-      case "2.11"      => "3.2.3"
-      case _           => "3.2.9"
-    }
-  final val scalatestPlusScalacheckVersion =
-    Def.map(scalaBinaryVersion) {
-      case "2.11"      => "3.2.3.0"
-      case _           => "3.2.9.0"
-    }
+  final val scalacheckVersion              = "1.15.3"
+  final val scalatestVersion               = "3.2.19"
+  final val scalatestPlusScalacheckVersion = "3.2.9.0"
   final val scalajsStubsVersion            = "1.0.0"
 
   val slf4j     = "org.slf4j"      % "slf4j-api"       % slf4jVersion

--- a/project/ProjectSettings.scala
+++ b/project/ProjectSettings.scala
@@ -1,4 +1,4 @@
-import sbt._
+import sbt.*
 
 /** Basic metadata about the project that gets pulled into the build */
 trait ProjectSettings
@@ -15,9 +15,9 @@ trait ProjectSettings
   override final val githubOrganization       = "Log4s"
   override final val githubProject            = "log4s"
 
-  override final val buildScalaVersion        = "2.12.15"
-  override final val extraScalaVersions       = Seq("2.11.12", "2.13.8", "3.0.2")
-  override final val minimumJavaVersion       = "1.7"
+  override final val buildScalaVersion        = "2.12.21"
+  override final val extraScalaVersions       = Seq("2.13.18", "3.3.7")
+  override final val minimumJavaVersion       = "1.8"
   override final val defaultOptimize          = true
   override final val defaultOptimizeGlobal    = true
   override final val defaultDisableAssertions = true

--- a/project/plugin-github-actions.sbt
+++ b/project/plugin-github-actions.sbt
@@ -1,1 +1,2 @@
-addSbtPlugin("org.typelevel" % "sbt-typelevel-github-actions" % "0.8.0")
+addSbtPlugin("org.typelevel" % "sbt-typelevel-github-actions" % "0.8.5")
+addSbtPlugin("org.typelevel" % "sbt-typelevel-github" % "0.8.5")

--- a/project/plugin-scalajs.sbt
+++ b/project/plugin-scalajs.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.8.0")
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
+addSbtPlugin("org.scala-js"       % "sbt-scalajs"              % "1.20.2")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.2")


### PR DESCRIPTION
Adds the `TypelevelScalaJSGitHubPlugin` to the build, which configures the Scala.js source map URI to point to GitHub. Sets the `-scalajs-mapSourceURI:` scalacOption so source-maps will point to GitHub, rather than a local file which will not exist for end users of log4s.

```sbt
sbt:Log4s Root> show coreJS/scalacOptions
---
[info] * -P:scalajs:mapSourceURI:file:/Users/hvanrijswijk1/ws/log4s/->https://raw.githubusercontent.com/Log4s/log4s/1f23b6c7cbc7400cce1f6670422461b62fa0211e/
```
